### PR TITLE
fix messages to preserve white space and wrap long urls

### DIFF
--- a/src/css/components/Message.scss
+++ b/src/css/components/Message.scss
@@ -7,6 +7,8 @@
     max-width: 60%;
     border-radius: 10px;
     display:block;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
   li.clearfix {


### PR DESCRIPTION
Fixes:
- preserves whitespaces and newlines
- wraps long urls

![whitespace fixes](https://user-images.githubusercontent.com/1256329/32138542-5883db00-bc02-11e7-8f9f-4cb294d8f5ba.png)

I was going to address the centered text issue, but I saw that it was already fixed in https://github.com/opsdroid/opsdroid-desktop/pull/13.